### PR TITLE
uninstall body-parser pacakage as express 4.16+ has inbuild json parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   },
   "homepage": "https://github.com/eddiejaoude/node-express-course#readme",
   "dependencies": {
-    "body-parser": "^1.19.0",
     "express": "^4.17.1"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,8 +1,8 @@
 const express = require("express");
 const app = express();
 
-const bodyParser = require("body-parser");
-app.use(bodyParser.json());
+
+app.use(express.json());
 
 const mockUserData = [{
         id: 1,


### PR DESCRIPTION
 there is express 4.17.1 in use, so instead of the body-parser package we can use inbuild JSON parse